### PR TITLE
Fix millify templatetag when value is None

### DIFF
--- a/contratospr/utils/templatetags/millify.py
+++ b/contratospr/utils/templatetags/millify.py
@@ -8,9 +8,12 @@ MILLNAMES = ["", "k", "M", "B", "T", "P", "E", "Z", "Y"]
 
 
 @register.filter
-def millify(n):
-    most_significant_part = math.floor(0 if n == 0 else math.log10(abs(n)) / 3)
+def millify(value=0):
+    number = value or 0
+    most_significant_part = math.floor(
+        0 if number == 0 else math.log10(abs(number)) / 3
+    )
     millidx = max(0, min(len(MILLNAMES) - 1, int(most_significant_part)))
-    result = n / 10 ** (3 * millidx)
+    result = number / 10 ** (3 * millidx)
 
     return f"{result:.0f}{MILLNAMES[millidx]}"


### PR DESCRIPTION
## Description

Fix `millify` template tag when value is `None`. Handles the case when no there is no contracts available in the home page.

Fixes #10 