### PR TITLE
Move Google creads to prod settings

### DIFF
--- a/contratospr/contracts/models.py
+++ b/contratospr/contracts/models.py
@@ -27,8 +27,11 @@ if settings.FILEPREVIEWS_API_KEY and settings.FILEPREVIEWS_API_SECRET:
 else:
     filepreviews = None
 
-service_account_info = json.loads(settings.GOOGLE_APPLICATION_CREDENTIALS)
-credentials = Credentials.from_service_account_info(service_account_info)
+if settings.GOOGLE_APPLICATION_CREDENTIALS:
+    service_account_info = json.loads(settings.GOOGLE_APPLICATION_CREDENTIALS)
+    credentials = Credentials.from_service_account_info(service_account_info)
+else:
+    credentials = None
 
 document_storage = import_string(settings.CONTRACTS_DOCUMENT_STORAGE)()
 
@@ -156,7 +159,7 @@ class Document(BaseModel):
             self.save(update_fields=["preview_data_file"])
 
     def detect_text(self):
-        if self.preview_data and self.preview_data["thumbnails"]:
+        if self.preview_data and self.preview_data["thumbnails"] and credentials:
             client = vision.ImageAnnotatorClient(credentials=credentials)
             results = []
             pages = []

--- a/contratospr/settings.py
+++ b/contratospr/settings.py
@@ -122,8 +122,6 @@ class Common(Configuration):
     FILEPREVIEWS_API_KEY = values.Value(environ_prefix=None)
     FILEPREVIEWS_API_SECRET = values.Value(environ_prefix=None)
 
-    GOOGLE_APPLICATION_CREDENTIALS = values.Value(environ_prefix=None)
-
     DEBUG_TOOLBAR_CONFIG = {
         "SHOW_TOOLBAR_CALLBACK": "contratospr.utils.debug_toolbar.show_toolbar"
     }
@@ -169,6 +167,8 @@ class Production(Staging):
     AWS_ACCESS_KEY_ID = values.SecretValue(environ_prefix=None)
     AWS_SECRET_ACCESS_KEY = values.SecretValue(environ_prefix=None)
     AWS_S3_BUCKET_NAME = values.Value(environ_prefix=None)
+
+    GOOGLE_APPLICATION_CREDENTIALS = values.Value(environ_prefix=None)
 
     CONTRACTS_DOCUMENT_STORAGE = "django_s3_storage.storage.S3Storage"
 


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing guidelines](https://github.com/TheIndexingProject/tracking-contratos-pr/blob/master/CONTRIBUTING.md).

## Description

Please describe your pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. When linking to an issue, please use `refs #...` in the description of the pull request.

Google credentials should not be needed when running the project locally. Google credentials were moved to the `Production` area in our settings file and the credentials variable in `contracts.models.py` is now set to __None__ when google credentials are not set.