### PR TITLE
Revert Google credential settings move

### DIFF
--- a/contratospr/settings.py
+++ b/contratospr/settings.py
@@ -122,6 +122,8 @@ class Common(Configuration):
     FILEPREVIEWS_API_KEY = values.Value(environ_prefix=None)
     FILEPREVIEWS_API_SECRET = values.Value(environ_prefix=None)
 
+    GOOGLE_APPLICATION_CREDENTIALS = values.Value(environ_prefix=None)
+
     DEBUG_TOOLBAR_CONFIG = {
         "SHOW_TOOLBAR_CALLBACK": "contratospr.utils.debug_toolbar.show_toolbar"
     }
@@ -167,8 +169,6 @@ class Production(Staging):
     AWS_ACCESS_KEY_ID = values.SecretValue(environ_prefix=None)
     AWS_SECRET_ACCESS_KEY = values.SecretValue(environ_prefix=None)
     AWS_S3_BUCKET_NAME = values.Value(environ_prefix=None)
-
-    GOOGLE_APPLICATION_CREDENTIALS = values.Value(environ_prefix=None)
 
     CONTRACTS_DOCUMENT_STORAGE = "django_s3_storage.storage.S3Storage"
 


### PR DESCRIPTION
## Description

Moved Google credentials back to the Common area of settings. The thought behind this is that a developer should be able to test the Google cloud vision service without setting the application into a production mode. 

Having the `GOOGLE_APPLICATION_CREDENTIALS` in the Common area of the settings makes this attribute optional, which is what was intended.